### PR TITLE
Update coreos-livepxe-rootfs.sh

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
@@ -23,10 +23,10 @@ elif [[ -n "${rootfs_url}" ]]; then
     # rootfs URL was provided as karg.  Fetch image, check its hash, and
     # unpack it.
     echo "Fetching rootfs image from ${rootfs_url}..."
-    if [[ ${rootfs_url} != http:* && ${rootfs_url} != https:* ]]; then
+    if [[ ${rootfs_url} != http:* && ${rootfs_url} != https:* && ${rootfs_url} != ftp:* ]]; then
         # Don't commit to supporting protocols we might not want to expose in
         # the long term.
-        echo "coreos.live.rootfs_url= supports HTTP and HTTPS only." >&2
+        echo "coreos.live.rootfs_url= supports HTTP, HTTPS and FTP only." >&2
         echo "Please fix your PXE configuration." >&2
         exit 1
     fi


### PR DESCRIPTION
Many Red Hat Customers still use FTP to host files and even documentation states the ftp examples. Can we introduce ftp as an acceptable protocol in rootfs_url?

https://docs.openshift.com/container-platform/4.6/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-ibm-z

Keeping it only to http/https might need to make additional efforts changing multiple documentations.